### PR TITLE
Public recipe browsing + Clerk-protected favorites & user recipes

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
 
   "scripts": {
+    "dev": "tsx watch src/server.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "ts-node src/server.ts",
+    "start": "node dist/apps/backend/src/server.js",
     "build": "tsc",
     "vercel-build": "prisma migrate deploy && prisma db seed && npm run build",
     "postinstall": "prisma generate"

--- a/apps/backend/src/api/v1/middleware/auth.middleware.ts
+++ b/apps/backend/src/api/v1/middleware/auth.middleware.ts
@@ -1,4 +1,8 @@
-import { createClerkClient, createClerkExpressWithAuth } from "@clerk/clerk-sdk-node";
+import {
+  createClerkClient,
+  createClerkExpressRequireAuth,
+  createClerkExpressWithAuth,
+} from "@clerk/clerk-sdk-node";
 import type { NextFunction, Request, Response } from "express";
 
 type ClerkRequest = Request & {
@@ -15,25 +19,36 @@ if (!publishableKey || !secretKey) {
   throw new Error("Missing Clerk backend environment variables");
 }
 
+const clerkClient = createClerkClient({
+  secretKey,
+  publishableKey,
+});
+
 export const clerkMiddleware = createClerkExpressWithAuth({
-  clerkClient: createClerkClient({
-    secretKey,
-    publishableKey,
-  }),
+  clerkClient,
   publishableKey,
   secretKey,
 })();
 
-export const requireClerkAuth = (
+export const requireClerkAuth = createClerkExpressRequireAuth({
+  clerkClient,
+  publishableKey,
+  secretKey,
+})();
+
+export const attachUserId = (
   req: Request,
   res: Response,
   next: NextFunction
 ) => {
   const authenticatedRequest = req as ClerkRequest;
 
-  if (!authenticatedRequest.auth?.userId) {
+  const userId = authenticatedRequest.auth?.userId;
+
+  if (!userId) {
     return res.status(401).json({ message: "Authentication required" });
   }
 
+  (req as Request & { userId: string }).userId = userId;
   return next();
 };

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,8 +3,12 @@ import cors from 'cors';
 import recipeRoutes from "./api/v1/routes/recipe.routes.js";
 import userRecipeRoutes from "./api/v1/routes/userRecipe.routes.js";
 import favoriteRoutes from "./api/v1/routes/favorite.routes.js";
-import { clerkMiddleware, requireClerkAuth } from "./api/v1/middleware/auth.middleware.js";
-
+import {
+  attachUserId,
+  clerkMiddleware,
+  requireClerkAuth,
+} from "./api/v1/middleware/auth.middleware.js";
+ 
 const app: Express = express();
 
 app.use(cors({
@@ -15,9 +19,9 @@ app.use(cors({
 app.use(express.json());
 app.use(clerkMiddleware);
 
-app.use("/api/v1/recipes", requireClerkAuth, recipeRoutes);
-app.use("/api/v1/user-recipes", requireClerkAuth, userRecipeRoutes);
-app.use("/api/v1/favorites", requireClerkAuth, favoriteRoutes);
+app.use("/api/v1/recipes", recipeRoutes);
+app.use("/api/v1/user-recipes", requireClerkAuth, attachUserId, userRecipeRoutes);
+app.use("/api/v1/favorites", requireClerkAuth, attachUserId, favoriteRoutes);
 
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', message: 'Recipe API is running' });

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,15 +1,11 @@
 import dotenv from 'dotenv';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
-
-import app from './app.js';
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 
 const PORT = process.env.PORT || 3001;
+
+const { default: app } = await import("./app.js");
 
 app.listen(PORT, () => {
   console.log(`Backend server running on port ${PORT}`);

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import './App.css';
 import { Routes, Route } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { SignedIn, SignedOut, SignIn, useAuth } from '@clerk/clerk-react';
+import { ClerkLoaded, ClerkLoading, SignedIn, SignedOut, SignIn, useAuth } from '@clerk/clerk-react';
 import Header from './components/header/Header';
 import Footer from './components/footer/Footer';
 import Home from './pages/Home';
@@ -61,17 +61,15 @@ function App() {
 
   return (
     <>
-      <SignedOut>
+      <ClerkLoading>
         <main className="auth-page">
           <div className="auth-card">
-            <h1>Recipe Management System</h1>
-            <p>Sign in with your email to manage recipes, favorites, and custom dishes.</p>
-            <SignIn routing="hash" fallbackRedirectUrl="/" signUpForceRedirectUrl="/" />
+            <h1>Loading…</h1>
           </div>
         </main>
-      </SignedOut>
+      </ClerkLoading>
 
-      <SignedIn>
+      <ClerkLoaded>
         <div className="app">
           <Header />
           <main className="app-main">
@@ -89,20 +87,53 @@ function App() {
               <Route
                 path="/favorites"
                 element={
-                  <Favorites
-                    favoriteRecipes={favoriteRecipes}
-                    removeFromFavorites={removeFromFavorites}
-                  />
+                  <>
+                    <SignedOut>
+                      <main className="auth-page">
+                        <div className="auth-card">
+                          <h1>Sign in required</h1>
+                          <p>Sign in to view and manage your favorites.</p>
+                          <SignIn routing="hash" fallbackRedirectUrl="/favorites" signUpForceRedirectUrl="/favorites" />
+                        </div>
+                      </main>
+                    </SignedOut>
+
+                    <SignedIn>
+                      <Favorites
+                        favoriteRecipes={favoriteRecipes}
+                        removeFromFavorites={removeFromFavorites}
+                      />
+                    </SignedIn>
+                  </>
                 }
               />
 
-              <Route path="/add-recipe" element={<AddRecipe />} />
+              <Route
+                path="/add-recipe"
+                element={
+                  <>
+                    <SignedOut>
+                      <main className="auth-page">
+                        <div className="auth-card">
+                          <h1>Sign in required</h1>
+                          <p>Sign in to submit your own recipes.</p>
+                          <SignIn routing="hash" fallbackRedirectUrl="/add-recipe" signUpForceRedirectUrl="/add-recipe" />
+                        </div>
+                      </main>
+                    </SignedOut>
+
+                    <SignedIn>
+                      <AddRecipe />
+                    </SignedIn>
+                  </>
+                }
+              />
             </Routes>
           </main>
 
           <Footer />
         </div>
-      </SignedIn>
+      </ClerkLoaded>
     </>
   );
 }

--- a/apps/frontend/src/components/Navigation/Nav.tsx
+++ b/apps/frontend/src/components/Navigation/Nav.tsx
@@ -1,5 +1,4 @@
 import { NavLink } from 'react-router-dom';
-import { UserButton } from '@clerk/clerk-react';
 import './Nav.css';
  
 export default function Nav() {
@@ -32,9 +31,6 @@ export default function Nav() {
           >
             Add Recipe
           </NavLink>
-        </li>
-        <li className="nav-user">
-          <UserButton afterSignOutUrl="/" />
         </li>
       </ul>
     </nav>

--- a/apps/frontend/src/components/header/Header.css
+++ b/apps/frontend/src/components/header/Header.css
@@ -6,10 +6,48 @@
 
 /* Top section with logo */
 .header-top {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   margin-bottom: 10px;
+}
+
+.header-spacer {
+  height: 1px;
+}
+
+.header-auth {
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.header-auth-button {
+  appearance: none;
+  border: 1px solid #666666;
+  background: transparent;
+  color: #666666;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.header-auth-button:hover {
+  color: #000000;
+  border-color: #000000;
+}
+
+.header-auth-button-primary {
+  background: #666666;
+  color: #ffffff;
+}
+
+.header-auth-button-primary:hover {
+  background: #000000;
+  border-color: #000000;
+  color: #ffffff;
 }
 
 .logo {

--- a/apps/frontend/src/components/header/Header.tsx
+++ b/apps/frontend/src/components/header/Header.tsx
@@ -1,12 +1,20 @@
 import './Header.css';
 import Nav from '../Navigation/Nav';
 import logo from '../../assets/Recipe_Management_Logo.png';
+import {
+  SignedIn,
+  SignedOut,
+  SignInButton,
+  SignUpButton,
+  UserButton,
+} from '@clerk/clerk-react';
  
 export default function Header() {
   return (
     <>
       <header className="app-header">
         <div className="header-top">
+          <div className="header-spacer" />
           <div className="logo-section">
             <a href="/">
               <img
@@ -15,6 +23,24 @@ export default function Header() {
                 className="logo"
               />
             </a>
+          </div>
+
+          <div className="header-auth">
+            <SignedIn>
+              <UserButton afterSignOutUrl="/" />
+            </SignedIn>
+            <SignedOut>
+              <SignInButton mode="modal">
+                <button type="button" className="header-auth-button">
+                  Sign in
+                </button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <button type="button" className="header-auth-button header-auth-button-primary">
+                  Sign up
+                </button>
+              </SignUpButton>
+            </SignedOut>
           </div>
         </div>
  

--- a/apps/frontend/src/components/recipe-card/RecipeCard.tsx
+++ b/apps/frontend/src/components/recipe-card/RecipeCard.tsx
@@ -1,5 +1,6 @@
 import './RecipeCard.css';
 import type {Recipe} from '../../../../../shared/types/Recipe';
+import { SignedIn, SignedOut, SignInButton } from '@clerk/clerk-react';
 
 interface RecipeCardProps {
     recipe: Recipe;
@@ -31,13 +32,23 @@ export default function RecipeCard({ recipe, onAddToFavorites, isFavorite }: Rec
                   {recipe.servings} servings
                 </span>
               </div>
+              <SignedIn>
                 <button
-                    onClick={() => onAddToFavorites(recipe)}
-                    disabled={isFavorite}
-                    className={isFavorite ? 'recipe-card-button favorited' : 'recipe-card-button'}
+                  onClick={() => onAddToFavorites(recipe)}
+                  disabled={isFavorite}
+                  className={isFavorite ? 'recipe-card-button favorited' : 'recipe-card-button'}
                 >
-                    {isFavorite ? ' Favorited' : ' Add to Favorites'}
+                  {isFavorite ? ' Favorited' : ' Add to Favorites'}
                 </button>
+              </SignedIn>
+
+              <SignedOut>
+                <SignInButton mode="modal">
+                  <button type="button" className="recipe-card-button">
+                    favorite
+                  </button>
+                </SignInButton>
+              </SignedOut>
             </div>
       </article>
     );

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This PR keeps the Home/recipe browsing experience open to everyone, while adding Clerk authentication where it actually matters.

On the backend, /api/v1/favorites and /api/v1/user-recipes are now protected with Clerk requireAuth, and we extract the authenticated userId from the token for downstream use. Unauthenticated requests get a clean 401.

On the frontend, users can browse recipes without signing in, but they’ll be prompted to sign in if they try to favorite a recipe, view the Favorites page, or submit a new user recipe. I also moved the auth controls into the header so sign in/sign up is always easy to find.